### PR TITLE
Try to get missing url tokens from object attributes

### DIFF
--- a/lib/rest_in_peace/api_call.rb
+++ b/lib/rest_in_peace/api_call.rb
@@ -8,6 +8,7 @@ module RESTinPeace
       @url_template = url_template
       @klass = klass
       @params = params
+      @attributes = {}
     end
 
     def get
@@ -43,8 +44,12 @@ module RESTinPeace
       sanitizer.leftover_params
     end
 
+    def attributes
+      @attributes = @klass.to_h if @klass.respond_to?(:to_h)
+    end
+
     def sanitizer
-      @sanitizer ||= RESTinPeace::TemplateSanitizer.new(@url_template, @params)
+      @sanitizer ||= RESTinPeace::TemplateSanitizer.new(@url_template, @params, attributes)
     end
 
     def convert_response(response)

--- a/lib/rest_in_peace/template_sanitizer.rb
+++ b/lib/rest_in_peace/template_sanitizer.rb
@@ -5,9 +5,10 @@ module RESTinPeace
 
     class IncompleteParams < RESTinPeace::DefaultError; end
 
-    def initialize(url_template, params)
+    def initialize(url_template, params, attributes)
       @url_template = url_template
       @params = params.dup
+      @attributes = attributes
       @url = nil
     end
 
@@ -16,6 +17,7 @@ module RESTinPeace
       @url = @url_template.dup
       tokens.each do |token|
         param = @params.delete(token.to_sym)
+        param ||= @attributes[token.to_sym]
         raise IncompleteParams, "Unknown parameter for token :#{token} found" unless param
         @url.sub!(%r{:#{token}}, param.to_s)
       end

--- a/spec/rest_in_peace/template_sanitizer_spec.rb
+++ b/spec/rest_in_peace/template_sanitizer_spec.rb
@@ -1,8 +1,8 @@
 require 'rest_in_peace/template_sanitizer'
 
 describe RESTinPeace::TemplateSanitizer do
-
-  let(:template_sanitizer) { RESTinPeace::TemplateSanitizer.new(url_template, params) }
+  let(:template_sanitizer) { RESTinPeace::TemplateSanitizer.new(url_template, params, attributes) }
+  let(:attributes) { {} }
 
   describe '#url' do
     subject { template_sanitizer.url }
@@ -47,6 +47,20 @@ describe RESTinPeace::TemplateSanitizer do
       let(:params) { { id: 1 } }
       let(:url_template) { '/a/:id' }
       specify { expect { subject }.to_not change { params } }
+    end
+
+    context 'tokens from attributes' do
+      let(:params) { { id: 1 } }
+      let(:attributes) { { a_id: 2 } }
+      let(:url_template) { '/a/:a_id/b/:id' }
+      specify { expect(subject).to eq('/a/2/b/1') }
+    end
+
+    context 'incomplete params and attributes' do
+      let(:params) { { id: 1 } }
+      let(:attributes) { {} }
+      let(:url_template) { '/a/:a_id/b/:id' }
+      specify { expect { subject }.to raise_error(RESTinPeace::TemplateSanitizer::IncompleteParams) }
     end
   end
 


### PR DESCRIPTION
When defining resource methods using other tokens than :id (typically
sub-resources, eg. `delete :destroy, /brands/:brand_id/things/:id`),
try to get the missing token (`:brand_id`) from the current object
instead of directly throwing an exception.