### PR TITLE
Only get needed attributes for sanitizing the url

### DIFF
--- a/lib/rest_in_peace/api_call.rb
+++ b/lib/rest_in_peace/api_call.rb
@@ -44,12 +44,8 @@ module RESTinPeace
       sanitizer.leftover_params
     end
 
-    def attributes
-      @attributes = @klass.to_h if @klass.respond_to?(:to_h)
-    end
-
     def sanitizer
-      @sanitizer ||= RESTinPeace::TemplateSanitizer.new(@url_template, @params, attributes)
+      @sanitizer ||= RESTinPeace::TemplateSanitizer.new(@url_template, @params, @klass)
     end
 
     def convert_response(response)

--- a/lib/rest_in_peace/template_sanitizer.rb
+++ b/lib/rest_in_peace/template_sanitizer.rb
@@ -5,10 +5,10 @@ module RESTinPeace
 
     class IncompleteParams < RESTinPeace::DefaultError; end
 
-    def initialize(url_template, params, attributes)
+    def initialize(url_template, params, klass)
       @url_template = url_template
       @params = params.dup
-      @attributes = attributes
+      @klass = klass
       @url = nil
     end
 
@@ -17,7 +17,7 @@ module RESTinPeace
       @url = @url_template.dup
       tokens.each do |token|
         param = @params.delete(token.to_sym)
-        param ||= @attributes[token.to_sym]
+        param ||= @klass.send(token) if @klass.respond_to?(token)
         raise IncompleteParams, "Unknown parameter for token :#{token} found" unless param
         @url.sub!(%r{:#{token}}, param.to_s)
       end

--- a/spec/rest_in_peace/template_sanitizer_spec.rb
+++ b/spec/rest_in_peace/template_sanitizer_spec.rb
@@ -1,90 +1,146 @@
 require 'rest_in_peace/template_sanitizer'
+require 'ostruct'
 
 describe RESTinPeace::TemplateSanitizer do
-  let(:template_sanitizer) { RESTinPeace::TemplateSanitizer.new(url_template, params, attributes) }
   let(:attributes) { {} }
+  let(:template_sanitizer) { RESTinPeace::TemplateSanitizer.new(url_template, params, klass) }
 
-  describe '#url' do
-    subject { template_sanitizer.url }
 
-    context 'single token' do
-      let(:params) { { id: 1 } }
-      let(:url_template) { '/a/:id' }
-      specify { expect(subject).to eq('/a/1') }
+  context 'with class' do
+    let(:klass) { OpenStruct }
+
+    describe '#url' do
+      subject { template_sanitizer.url }
+
+      context 'single token' do
+        let(:params) { { id: 1 } }
+        let(:url_template) { '/a/:id' }
+        specify { expect(subject).to eq('/a/1') }
+      end
+
+      context 'multiple token' do
+        let(:params) { { id: 2, a_id: 1 } }
+        let(:url_template) { '/a/:a_id/b/:id' }
+        specify { expect(subject).to eq('/a/1/b/2') }
+      end
+
+      context 'incomplete params' do
+        let(:params) { { id: 1 } }
+        let(:url_template) { '/a/:a_id/b/:id' }
+        specify { expect { subject }.to raise_error(RESTinPeace::TemplateSanitizer::IncompleteParams) }
+      end
     end
 
-    context 'multiple token' do
-      let(:params) { { id: 2, a_id: 1 } }
-      let(:url_template) { '/a/:a_id/b/:id' }
-      specify { expect(subject).to eq('/a/1/b/2') }
-    end
-
-    context 'tokens with substrings' do
-      let(:params) { { element: 'asd', element_id: 1 } }
-      let(:url_template) { '/a/:element/b/:element_id' }
-      specify { expect(subject).to eq('/a/asd/b/1') }
-    end
-
-    context 'tokens with substrings, reverse order' do
-      let(:params) { { element: 'asd', element_id: 1 } }
-      let(:url_template) { '/a/:element_id/b/:element' }
-      specify { expect(subject).to eq('/a/1/b/asd') }
-    end
-
-    context 'incomplete params' do
+    describe '#tokens' do
       let(:params) { {} }
+
+      context 'single token' do
+        let(:url_template) { '/a/:id' }
+        subject { template_sanitizer.tokens }
+        specify { expect(subject).to eq(%w(id)) }
+      end
+
+      context 'multiple tokens' do
+        let(:url_template) { '/a/:a_id/b/:id' }
+        subject { template_sanitizer.tokens }
+        specify { expect(subject).to eq(%w(a_id id)) }
+      end
+    end
+
+    describe '#leftover_params' do
+      let(:params) { { id: 1, name: 'test' } }
       let(:url_template) { '/a/:id' }
-      specify { expect { subject }.to raise_error(RESTinPeace::TemplateSanitizer::IncompleteParams) }
-    end
+      subject { template_sanitizer.leftover_params }
 
-    context 'immutability of the url template' do
-      let(:params) { { id: 1 } }
-      let(:url_template) { '/a/:id' }
-      specify { expect { subject }.to_not change { url_template } }
-    end
-
-    context 'immutability of the params' do
-      let(:params) { { id: 1 } }
-      let(:url_template) { '/a/:id' }
-      specify { expect { subject }.to_not change { params } }
-    end
-
-    context 'tokens from attributes' do
-      let(:params) { { id: 1 } }
-      let(:attributes) { { a_id: 2 } }
-      let(:url_template) { '/a/:a_id/b/:id' }
-      specify { expect(subject).to eq('/a/2/b/1') }
-    end
-
-    context 'incomplete params and attributes' do
-      let(:params) { { id: 1 } }
-      let(:attributes) { {} }
-      let(:url_template) { '/a/:a_id/b/:id' }
-      specify { expect { subject }.to raise_error(RESTinPeace::TemplateSanitizer::IncompleteParams) }
+      specify { expect(subject).to eq({name: 'test'}) }
     end
   end
 
-  describe '#tokens' do
-    let(:params) { {} }
+  context 'with object' do
+    let(:klass) { OpenStruct.new(attributes) }
 
-    context 'single token' do
+    describe '#url' do
+      subject { template_sanitizer.url }
+
+      context 'single token' do
+        let(:params) { { id: 1 } }
+        let(:url_template) { '/a/:id' }
+        specify { expect(subject).to eq('/a/1') }
+      end
+
+      context 'multiple token' do
+        let(:params) { { id: 2, a_id: 1 } }
+        let(:url_template) { '/a/:a_id/b/:id' }
+        specify { expect(subject).to eq('/a/1/b/2') }
+      end
+
+      context 'tokens with substrings' do
+        let(:params) { { element: 'asd', element_id: 1 } }
+        let(:url_template) { '/a/:element/b/:element_id' }
+        specify { expect(subject).to eq('/a/asd/b/1') }
+      end
+
+      context 'tokens with substrings, reverse order' do
+        let(:params) { { element: 'asd', element_id: 1 } }
+        let(:url_template) { '/a/:element_id/b/:element' }
+        specify { expect(subject).to eq('/a/1/b/asd') }
+      end
+
+      context 'incomplete params' do
+        let(:params) { {} }
+        let(:url_template) { '/a/:id' }
+        specify { expect { subject }.to raise_error(RESTinPeace::TemplateSanitizer::IncompleteParams) }
+      end
+
+      context 'immutability of the url template' do
+        let(:params) { { id: 1 } }
+        let(:url_template) { '/a/:id' }
+        specify { expect { subject }.to_not change { url_template } }
+      end
+
+      context 'immutability of the params' do
+        let(:params) { { id: 1 } }
+        let(:url_template) { '/a/:id' }
+        specify { expect { subject }.to_not change { params } }
+      end
+
+      context 'tokens from attributes' do
+        let(:params) { { id: 1 } }
+        let(:attributes) { { a_id: 2 } }
+        let(:url_template) { '/a/:a_id/b/:id' }
+        specify { expect(subject).to eq('/a/2/b/1') }
+      end
+
+      context 'incomplete params and attributes' do
+        let(:params) { { id: 1 } }
+        let(:attributes) { {} }
+        let(:url_template) { '/a/:a_id/b/:id' }
+        specify { expect { subject }.to raise_error(RESTinPeace::TemplateSanitizer::IncompleteParams) }
+      end
+    end
+
+    describe '#tokens' do
+      let(:params) { {} }
+
+      context 'single token' do
+        let(:url_template) { '/a/:id' }
+        subject { template_sanitizer.tokens }
+        specify { expect(subject).to eq(%w(id)) }
+      end
+
+      context 'multiple tokens' do
+        let(:url_template) { '/a/:a_id/b/:id' }
+        subject { template_sanitizer.tokens }
+        specify { expect(subject).to eq(%w(a_id id)) }
+      end
+    end
+
+    describe '#leftover_params' do
+      let(:params) { { id: 1, name: 'test' } }
       let(:url_template) { '/a/:id' }
-      subject { template_sanitizer.tokens }
-      specify { expect(subject).to eq(%w(id)) }
+      subject { template_sanitizer.leftover_params }
+
+      specify { expect(subject).to eq({name: 'test'}) }
     end
-
-    context 'multiple tokens' do
-      let(:url_template) { '/a/:a_id/b/:id' }
-      subject { template_sanitizer.tokens }
-      specify { expect(subject).to eq(%w(a_id id)) }
-    end
-  end
-
-  describe '#leftover_params' do
-    let(:params) { { id: 1, name: 'test' } }
-    let(:url_template) { '/a/:id' }
-    subject { template_sanitizer.leftover_params }
-
-    specify { expect(subject).to eq({name: 'test'}) }
   end
 end


### PR DESCRIPTION
Previously, when sanitizing the url, we called `to_h` on the object to
get all the available attributes to substitute in the url. This could
cause api requests in the background if there were any overwritten
attribute getters (e.g. to map nested resources as objects). This
commit changes the sanitizer to only get needed attributes for
sanitizing.