### PR TITLE
Fix put and post handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ gemfile:
   - gemfiles/Gemfile.rails-4.2.x
 script:
   - bundle exec rake spec
+before_install: gem install bundler

--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ resource.create # calls "POST /rip"
 resource.reload # calls "GET /rip/1"
 ```
 
-**For any writing action (`:post`, `:put`, `:patch`) RESTinPeace will include the *changed* attributes in the body and `id`.**
-
 #### Collection
 
 If you define anything inside the `collection` block, it will define a method on the class:
@@ -118,6 +116,19 @@ end
 resource = Resource.find(id: 1) # calls "GET /rip/1"
 resource = Resource.find_on_other(other_id: 42, id: 1337) # calls "GET /other/42/rip/1337"
 ```
+
+#### HTTP Verb differences
+
+Depending on the given HTTP verb, a different set of attributes will be used as payload and query parameters.
+
+HTTP Verb           | passed | all | only changed and id | only id
+------------------- | :----: | :-: | :-----------------: | :-----:
+`GET` on collection | ✔      | ✘   | ✘                   | ✘
+`GET` on resource   | ✘      | ✔   | ✘                   | ✘
+`POST`              | ✘      | ✔   | ✘                   | ✘
+`PUT`               | ✘      | ✔   | ✘                   | ✘
+`PATCH`             | ✘      | ✘   | ✔                   | ✘
+`DELETE`            | ✘      | ✘   | ✘                   | ✔
 
 #### Pagination
 

--- a/lib/rest_in_peace.rb
+++ b/lib/rest_in_peace.rb
@@ -17,11 +17,15 @@ module RESTinPeace
     set_attributes attributes
   end
 
-  def payload
+  def payload(changes_only = true)
     hash_representation = { id: id }
-    changed.each do |key|
-      value = send(key)
-      hash_representation[key.to_sym] = hash_representation_of_object(value)
+    if changes_only
+      changed.each do |key|
+        value = send(key)
+        hash_representation[key.to_sym] = hash_representation_of_object(value)
+      end
+    else
+      hash_representation = to_h
     end
     if self.class.rip_namespace
       { id: id, self.class.rip_namespace => hash_representation }

--- a/lib/rest_in_peace/definition_proxy/resource_method_definitions.rb
+++ b/lib/rest_in_peace/definition_proxy/resource_method_definitions.rb
@@ -24,7 +24,7 @@ module RESTinPeace
       def post(method_name, url_template)
         @target.rip_registry[:resource] << { method: :post, name: method_name, url: url_template }
         @target.send(:define_method, method_name) do
-          call = RESTinPeace::ApiCall.new(api, url_template, self, payload)
+          call = RESTinPeace::ApiCall.new(api, url_template, self, payload(false))
           call.post
         end
       end
@@ -32,7 +32,7 @@ module RESTinPeace
       def put(method_name, url_template)
         @target.rip_registry[:resource] << { method: :put, name: method_name, url: url_template }
         @target.send(:define_method, method_name) do
-          call = RESTinPeace::ApiCall.new(api, url_template, self, payload)
+          call = RESTinPeace::ApiCall.new(api, url_template, self, payload(false))
           call.put
         end
       end

--- a/spec/rest_in_peace/definition_proxy/resource_method_definitions_spec.rb
+++ b/spec/rest_in_peace/definition_proxy/resource_method_definitions_spec.rb
@@ -37,7 +37,20 @@ describe RESTinPeace::DefinitionProxy::ResourceMethodDefinitions do
     end
   end
 
-  shared_examples_for 'an instance method with parameters' do
+  shared_examples_for 'an instance method with all attributes' do
+    describe 'parameter and arguments handling' do
+      it 'uses all the attributes of the class' do
+        expect(RESTinPeace::ApiCall).to receive(:new).
+          with(target.api, url_template, instance, instance.payload(false)).
+          and_return(api_call_double)
+
+        subject.send(http_verb, method_name, url_template)
+        instance.send(method_name)
+      end
+    end
+  end
+
+  shared_examples_for 'an instance method with changed attributes' do
     describe 'parameter and arguments handling' do
       it 'uses the attributes of the class' do
         expect(RESTinPeace::ApiCall).to receive(:new).
@@ -50,7 +63,7 @@ describe RESTinPeace::DefinitionProxy::ResourceMethodDefinitions do
     end
   end
 
-  shared_examples_for 'an instance method without parameters' do
+  shared_examples_for 'an instance method without attributes' do
     describe 'parameter and arguments handling' do
       it 'provides the id only' do
         expect(RESTinPeace::ApiCall).to receive(:new).
@@ -71,7 +84,7 @@ describe RESTinPeace::DefinitionProxy::ResourceMethodDefinitions do
     end
 
     describe 'the created method' do
-      it_behaves_like 'an instance method with parameters' do
+      it_behaves_like 'an instance method with changed attributes' do
         let(:http_verb) { :get }
         let(:method_name) { :reload }
         let(:url_template) { '/a/:id' }
@@ -87,7 +100,7 @@ describe RESTinPeace::DefinitionProxy::ResourceMethodDefinitions do
     end
 
     describe 'the created method' do
-      it_behaves_like 'an instance method with parameters' do
+      it_behaves_like 'an instance method with changed attributes' do
         let(:http_verb) { :patch }
         let(:method_name) { :save }
         let(:url_template) { '/a/:id' }
@@ -103,7 +116,7 @@ describe RESTinPeace::DefinitionProxy::ResourceMethodDefinitions do
     end
 
     describe 'the created method' do
-      it_behaves_like 'an instance method with parameters' do
+      it_behaves_like 'an instance method with all attributes' do
         let(:http_verb) { :post }
         let(:method_name) { :create }
         let(:url_template) { '/a/:id' }
@@ -119,7 +132,7 @@ describe RESTinPeace::DefinitionProxy::ResourceMethodDefinitions do
     end
 
     describe 'the created method' do
-      it_behaves_like 'an instance method with parameters' do
+      it_behaves_like 'an instance method with all attributes' do
         let(:http_verb) { :put }
         let(:method_name) { :update }
         let(:url_template) { '/a/:id' }
@@ -135,7 +148,7 @@ describe RESTinPeace::DefinitionProxy::ResourceMethodDefinitions do
     end
 
     describe 'the created method' do
-      it_behaves_like 'an instance method without parameters' do
+      it_behaves_like 'an instance method without attributes' do
         let(:http_verb) { :delete }
         let(:method_name) { :destroy }
         let(:url_template) { '/a/:id' }


### PR DESCRIPTION
`PUT` replaces a whole resource, so we have to make sure all the given
attributes are used in the payload of a request

`POST` creates a resource, it makes no sense to just provide the
changed attributes in a request