### PR TITLE
[Bugfix] Catches HTTP 422 validation errors and add them to current ActiveModel instance.

### DIFF
--- a/lib/rest_in_peace/response_converter.rb
+++ b/lib/rest_in_peace/response_converter.rb
@@ -42,7 +42,14 @@ module RESTinPeace
     end
 
     def convert_from_hash(entity = body, instance = existing_instance)
-      instance.force_attributes_from_hash entity
+      entity_with_indifferent_access = entity.with_indifferent_access
+
+      # We received a validation error and we need to add it to the model.
+      if entity_with_indifferent_access[:status] == 422
+        instance.errors.add(:base, entity_with_indifferent_access[:message])
+      else
+        instance.force_attributes_from_hash entity
+      end
       instance
     end
 


### PR DESCRIPTION
### TL;DR

Any 422 errors coming back to `Rest-in-Peace` were not added to the current ActiveModel instance errors. This instance was therefore falsely valid.

Please still have a look at "Things to discuss in this PR".

### Background story

This problem only concerns the applications that uses the [Raise Errors Middleware](https://github.com/ninech/REST-in-Peace/blob/master/lib/rest_in_peace/faraday/raise_errors_middleware.rb) along with the [RESTinPeace#ActiveModelAPI](https://github.com/ninech/REST-in-Peace/blob/master/lib/rest_in_peace/active_model_api.rb).

When receiving a HTTP *unprocessable entity* error (code `422`), `REST-in-Peace` returned an object without any errors in the ActiveModel instance. It was later considered valid when using in other applications.

### Why it happened

When receiving a `422` response, we were trying to [set this response hash as attributes to the current instance](https://github.com/ninech/REST-in-Peace/blob/master/lib/rest_in_peace/response_converter.rb#L44). Unfortunately, this would not work because [the `status` and `message` keys do not exist in an ActiveModel object](https://github.com/ninech/REST-in-Peace/blob/master/lib/rest_in_peace.rb#L66). And even if they did, the instance would still be considered valid.

### What's the fix?

When converting the response, we now check if we have a `422` code. If we do, we [set an error in the current ActiveModel instance](https://github.com/ninech/REST-in-Peace/pull/30/files#diff-e15fb0117a222c8f07feefd480ecdb0fR49).

### Things to discuss in this PR

If you do not use the [Raise Errors Middleware](https://github.com/ninech/REST-in-Peace/blob/master/lib/rest_in_peace/faraday/raise_errors_middleware.rb) but you still use the [RESTinPeace#ActiveModelAPI](https://github.com/ninech/REST-in-Peace/blob/master/lib/rest_in_peace/active_model_api.rb), this will make RESTinPeace crash.

This is because you do not raise an exception to get validation errors (goal of the middleware), but you don't have anything to validate them with since you don't use the ActiveModelAPI.

**Suggestion:** I would therefore say in the docs OR enforce directly in the code that **we cannot use ActiveModelAPI without using the Middleware.**

**Question:** Is there a case where we could use `ActiveModelAPI` without wanting the 422 errors coming to us in the code?