### PR TITLE
Only send write attributes in payload

### DIFF
--- a/lib/rest_in_peace.rb
+++ b/lib/rest_in_peace.rb
@@ -25,8 +25,9 @@ module RESTinPeace
         hash_representation[key.to_sym] = hash_representation_of_object(value)
       end
     else
-      hash_representation = to_h
+      hash_representation.merge! to_h.reject { |k, _| !write_attribute?(k) }
     end
+
     if self.class.rip_namespace
       { id: id, self.class.rip_namespace => hash_representation }
     else
@@ -81,6 +82,10 @@ module RESTinPeace
     return object.payload if object.respond_to?(:payload)
     return object.map { |element| hash_representation_of_object(element) } if object.is_a?(Array)
     object
+  end
+
+  def write_attribute?(attribute)
+    self.class.rip_attributes[:write].include?(attribute.to_sym)
   end
 
   module ClassMethods

--- a/lib/rest_in_peace.rb
+++ b/lib/rest_in_peace.rb
@@ -25,7 +25,7 @@ module RESTinPeace
         hash_representation[key.to_sym] = hash_representation_of_object(value)
       end
     else
-      hash_representation.merge! to_h.reject { |k, _| !write_attribute?(k) }
+      hash_representation.merge! to_h.keep_if { |key| write_attribute?(key) }
     end
 
     if self.class.rip_namespace

--- a/spec/rest_in_peace_spec.rb
+++ b/spec/rest_in_peace_spec.rb
@@ -143,6 +143,32 @@ describe RESTinPeace do
           subject.payload
         end
       end
+
+      context 'all write attributes' do
+        specify do
+          expect(subject.payload(false)).to eq(
+            id: 1,
+            my_array: ['element'],
+            my_hash: { element1: 'yolo' },
+            array_with_hash: [{ element1: 'yolo' }],
+            overridden_attribute: 'something else',
+            description: 'old description'
+          )
+        end
+      end
+
+      context 'changes only' do
+        specify do
+          expect(subject.payload(true)).to eq(
+            id: 1,
+            my_array: ['element'],
+            my_hash: { element1: 'yolo' },
+            array_with_hash: [{ element1: 'yolo' }],
+            overridden_attribute: 'something else',
+            description: 'old description'
+          )
+        end
+      end
     end
 
     context 'with a namespace defined' do
@@ -152,7 +178,7 @@ describe RESTinPeace do
 
           rest_in_peace do
             attributes do
-              read :id
+              read :id, :relation
               write :name, :description
             end
 


### PR DESCRIPTION
When using a method that sends the whole resource (PUT, POST), we always send all attributes of the object. This PR changes the behaviour to only send the write attributes defined in the `write` block of an object.