### PR TITLE
:bug: Fix the error reporting an ActiveModel instance.

### DIFF
--- a/lib/rest_in_peace/active_model_api.rb
+++ b/lib/rest_in_peace/active_model_api.rb
@@ -63,8 +63,10 @@ module RESTinPeace
     end
 
     def errors=(new_errors)
-      new_errors.each do |key, value|
-        errors.add(key.to_sym, [value].flatten)
+      new_errors.each do |field, errors|
+        errors.each do |error|
+          self.errors.add(field.to_sym, error)
+        end
       end
     end
   end

--- a/spec/rest_in_peace/active_model_api_spec.rb
+++ b/spec/rest_in_peace/active_model_api_spec.rb
@@ -176,7 +176,7 @@ describe RESTinPeace do
       end
 
       let(:description) { 'desc' }
-      let(:errors) { { description: ['must not be empty'] } }
+      let(:errors)      { { description: ['must not be empty'] } }
 
       specify { expect(instance).to respond_to(:read_attribute_for_validation).with(1).argument }
       specify { expect(instance.read_attribute_for_validation(:description)).to eq('desc') }
@@ -187,6 +187,12 @@ describe RESTinPeace do
 
       describe '#errors=' do
         specify { expect { instance.errors = errors }.to change { instance.errors.count } }
+
+        it 'correctly adds the error to the instance' do
+          instance.errors = errors
+
+          expect(instance.errors[:description]).to eq(['must not be empty'])
+        end
       end
 
       describe '#valid?' do


### PR DESCRIPTION
### The problem

Validation errors for an ActiveModel are not correctly added to the instance:

![Problem](https://cloud.githubusercontent.com/assets/1400944/20181418/636ed718-a75e-11e6-965a-16d9e690d3b5.png)

### The cause

[This commit](https://github.com/ninech/REST-in-Peace/commit/27b385e73bc2bba4b2b39398a2141ff0314e0007)  has changed the method from `set` to `add`, but they unfortunately don't have the same API:

+ `set` allows you to add all the errors for a given field at once
+ `add` allows you to add one error at a time for a given field

### The fix

In this PR, we add the validation errors for a field one by one.