### PR TITLE
Only evaluate write attributes when creating the payload (fix #30707)

### DIFF
--- a/lib/rest_in_peace.rb
+++ b/lib/rest_in_peace.rb
@@ -3,7 +3,6 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'rest_in_peace/definition_proxy'
 
 module RESTinPeace
-
   def self.included(base)
     base.send :extend, ClassMethods
     base.send :include, ActiveModel::Dirty

--- a/lib/rest_in_peace.rb
+++ b/lib/rest_in_peace.rb
@@ -24,7 +24,7 @@ module RESTinPeace
         hash_representation[key.to_sym] = hash_representation_of_object(value)
       end
     else
-      hash_representation.merge! to_h.keep_if { |key| write_attribute?(key) }
+      hash_representation.merge!(to_write_only_hash)
     end
 
     if self.class.rip_namespace
@@ -55,9 +55,11 @@ module RESTinPeace
 
   def to_h
     hash_representation = {}
+
     self.class.rip_attributes.values.flatten.each do |attr|
       hash_representation[attr] = send(attr)
     end
+
     hash_representation
   end
 
@@ -108,6 +110,14 @@ module RESTinPeace
         read: [],
         write: [],
       }
+    end
+  end
+
+  private
+
+  def to_write_only_hash
+    self.class.rip_attributes[:write].inject({}) do |h, attr|
+      h.merge(attr => send(attr))
     end
   end
 end

--- a/spec/rest_in_peace_spec.rb
+++ b/spec/rest_in_peace_spec.rb
@@ -1,10 +1,11 @@
 require 'rest_in_peace'
 
 describe RESTinPeace do
-
   let(:extended_class) do
     Class.new do
       include RESTinPeace
+
+      attr_writer :relation
 
       rest_in_peace do
         attributes do
@@ -15,10 +16,6 @@ describe RESTinPeace do
 
       def overridden_attribute
         'something else'
-      end
-
-      def relation=(v)
-        @relation = v
       end
 
       def self_defined_method


### PR DESCRIPTION
### Background

When creating a payload for a PUT/POST request, we are evaluating all the attributes of the object (read and write).

### The problem

if an object has overridden some read attributes, they will be executed and that can cause errors (see the example below):

```ruby
class MyClass
  include RESTinPeace

  rest_in_peace do
    use_api ->() { My.api }

    attributes do
      read :first_attribute
      write :second_attribute
    end
  end

  def first_attribute
    @first_attribute.map { |e| puts e }
  end

  resource do
    post :create, '/my_route'
  end

  acts_as_active_model
end

# This will result in an error in the first_attribute method, as it currently gets executed.
MyClass.new.create
```

### Chosen fix

When creating the payload, [only evaluate the write attributes](https://github.com/ninech/REST-in-Peace/pull/36/files#diff-98a48164ba05a3feebc2acb0a1df9dc2R57).