### PR TITLE
Use Faraday 1.0 exception classes

### DIFF
--- a/lib/rest_in_peace/faraday/raise_errors_middleware.rb
+++ b/lib/rest_in_peace/faraday/raise_errors_middleware.rb
@@ -8,15 +8,15 @@ module RESTinPeace
       def on_complete(env)
         case env[:status]
         when 404
-          raise ::Faraday::Error::ResourceNotFound, response_values(env)
+          raise ::Faraday::ResourceNotFound, response_values(env)
         when 407
           # mimic the behavior that we get with proxy requests with HTTPS
-          raise ::Faraday::Error::ConnectionFailed, %{407 "Proxy Authentication Required "}
+          raise ::Faraday::ConnectionFailed, %{407 "Proxy Authentication Required "}
         when 422
           # do not raise an error as 422 from a rails app means validation errors
           # and response body contains the validation errors
         when CLIENT_ERROR_STATUSES
-          raise ::Faraday::Error::ClientError, response_values(env)
+          raise ::Faraday::ClientError, response_values(env)
         end
       end
 


### PR DESCRIPTION
Faraday has changed the namespace of its exception classes in 1.0. We now switch to these new classes to support Faraday 1.0 and higher.