### PR TITLE
Cleanup the build matrix for old dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,17 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.0.0
-  - 2.1.2
-  - 2.2.5
-  - 2.3.1
-  - 2.3.4
   - 2.4.1
+  - 2.6.6
+  - 2.7.2
 gemfile:
-  - gemfiles/Gemfile.activemodel-3.2.x
-  - gemfiles/Gemfile.activemodel-4.0.x
-  - gemfiles/Gemfile.activemodel-4.1.x
   - gemfiles/Gemfile.activemodel-4.2.x
-  - gemfiles/Gemfile.activemodel-5.0.x
   - gemfiles/Gemfile.activemodel-5.1.x
+  - gemfiles/Gemfile.activemodel-5.2.x
 script:
   - bundle exec rake spec
 before_install: gem install bundler
-matrix:
-  exclude:
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.activemodel-5.0.x
-    - rvm: 2.1.2
-      gemfile: gemfiles/Gemfile.activemodel-5.0.x
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.activemodel-5.1.x
-    - rvm: 2.1.2
-      gemfile: gemfiles/Gemfile.activemodel-5.1.x
+matrix: {}
 notifications:
   email: false
   slack:

--- a/gemfiles/Gemfile.activemodel-3.2.x
+++ b/gemfiles/Gemfile.activemodel-3.2.x
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activemodel', '~> 3.2.0'
-gem 'listen', '~> 3.0.7'

--- a/gemfiles/Gemfile.activemodel-4.0.x
+++ b/gemfiles/Gemfile.activemodel-4.0.x
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activemodel', '~> 4.0.0'
-gem 'listen', '~> 3.0.7'

--- a/gemfiles/Gemfile.activemodel-4.1.x
+++ b/gemfiles/Gemfile.activemodel-4.1.x
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activemodel', '~> 4.1.0'
-gem 'listen', '~> 3.0.7'

--- a/gemfiles/Gemfile.activemodel-5.2.x
+++ b/gemfiles/Gemfile.activemodel-5.2.x
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activemodel', '~> 5.0.0'
+gem 'activemodel', '~> 5.2.0'


### PR DESCRIPTION
Removes tests for some old versions of ActiveModel and also Ruby. Adds tests for ActiveModel 5.2.