### PR TITLE
Add support for activemodel 7, drop support for 4.2

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,15 +16,19 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.4.10, 2.5.8, 2.6.6, 2.7.2]
-        activemodel: [4.2.x, 5.1.x, 5.2.x, 6.0.x, 6.1.x]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.6]
+        activemodel: [5.1.x, 5.2.x, 6.0.x, 6.1.x, 7.0.x]
         exclude:
-          - ruby-version: 2.7.2
-            activemodel: 4.2.x
           - ruby-version: 2.4.10
             activemodel: 6.0.x
           - ruby-version: 2.4.10
             activemodel: 6.1.x
+          - ruby-version: 2.4.10
+            activemodel: 7.0.x
+          - ruby-version: 2.5.9
+            activemodel: 7.0.x
+          - ruby-version: 2.6.10
+            activemodel: 7.0.x
 
     steps:
     - uses: actions/checkout@v2

--- a/gemfiles/Gemfile.activemodel-4.2.x
+++ b/gemfiles/Gemfile.activemodel-4.2.x
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activemodel', '~> 4.2.0'
-gem 'listen', '~> 3.0.7'

--- a/gemfiles/Gemfile.activemodel-7.0.x
+++ b/gemfiles/Gemfile.activemodel-7.0.x
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activemodel', '~> 7.0.0'

--- a/rest-in-peace.gemspec
+++ b/rest-in-peace.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'activemodel', '>= 3.2', '< 7'
+  s.required_ruby_version = '>= 2.4'
+  s.add_runtime_dependency 'activemodel', '>= 5.0', '< 8'
   s.add_runtime_dependency 'addressable', '~> 2.5'
 
   s.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
ActiveModel 7.0 is now supported. ActiveModel 4.2 should still work but it's not tested anymore.